### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,8 @@
 name: tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/jpmorby/taskman/security/code-scanning/1](https://github.com/jpmorby/taskman/security/code-scanning/1)

In general, the problem is fixed by explicitly declaring a `permissions:` block that restricts the `GITHUB_TOKEN` to the minimal scopes required. For this workflow, the steps only need to read repository contents (for `actions/checkout`) and do not appear to require any write access to GitHub resources such as contents, pull requests, or issues.

The best fix, without changing existing functionality, is to add a `permissions:` block at the workflow root (top-level, alongside `name:` and `on:`). This will apply to all jobs in the workflow, including `ci`, and limit the token to read-only on repository contents. Concretely, in `.github/workflows/tests.yml`, add:

```yaml
permissions:
  contents: read
```

between the `name: tests` line and the `on:` block. No other changes are needed; all existing steps (checkout, setup, install, build, tests, linting) will continue to work, because they only require read access to the repository.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
