### PR TITLE
Serve security.txt from a route so it cannot silently expire

### DIFF
--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,2 +1,0 @@
-Contact: mailto:security@fxrm.com
-Expires: 2027-07-08T00:00:00.000Z

--- a/routes/web.php
+++ b/routes/web.php
@@ -78,3 +78,22 @@ Route::middleware([
 });
 
 require __DIR__.'/auth.php';
+
+// RFC 9116. Served from a route rather than a static file because Expires must
+// always be a future date — a checked-in one lapses silently and researchers are
+// told to treat the whole file as invalid. Rolls on the month so the body is
+// stable day to day.
+Route::get('/.well-known/security.txt', function () {
+    $fields = [
+        'Contact' => 'mailto:security@fxrm.com',
+        'Expires' => now()->addYear()->startOfMonth()->toIso8601ZuluString(),
+        'Preferred-Languages' => 'en',
+        'Canonical' => url('/.well-known/security.txt'),
+    ];
+
+    $body = collect($fields)
+        ->map(fn (string $value, string $field) => "{$field}: {$value}")
+        ->implode("\n")."\n";
+
+    return response($body, 200, ['Content-Type' => 'text/plain; charset=utf-8']);
+})->name('security.txt');

--- a/tests/Feature/SecurityTxtTest.php
+++ b/tests/Feature/SecurityTxtTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Support\Carbon;
+
+function securityTxt(): string
+{
+    return test()->get('/.well-known/security.txt')->getContent();
+}
+
+it('serves security.txt as plain text', function () {
+    $response = $this->get('/.well-known/security.txt');
+
+    $response->assertOk();
+    expect($response->headers->get('Content-Type'))->toStartWith('text/plain');
+});
+
+it('advertises the security contact', function () {
+    expect(securityTxt())->toContain('Contact: mailto:security@fxrm.com');
+});
+
+it('states a canonical url and language', function () {
+    expect(securityTxt())
+        ->toContain('Canonical: '.url('/.well-known/security.txt'))
+        ->toContain('Preferred-Languages: en');
+});
+
+// The reason this is a route at all: a hard-coded Expires lapses silently and
+// the file is then treated as invalid, so it has to stay ahead of "now"
+// whenever it is fetched.
+it('always expires in the future, however far the clock is wound on', function () {
+    Carbon::setTestNow('2030-05-05 12:00:00');
+
+    preg_match('/^Expires: (.+)$/m', securityTxt(), $matches);
+
+    expect(Carbon::parse($matches[1]))->toBeGreaterThan(Carbon::now());
+});
+
+// RFC 9116 §2.5.5 says a value more than a year out should not be used.
+it('expires within a year, per RFC 9116', function () {
+    preg_match('/^Expires: (.+)$/m', securityTxt(), $matches);
+
+    expect(Carbon::parse($matches[1]))->toBeLessThanOrEqual(Carbon::now()->addYear());
+});


### PR DESCRIPTION
`https://task.me.uk/.well-known/security.txt` was a two-line static file with `Expires: 2027-07-08T00:00:00.000Z` hard-coded and nothing to move it. RFC 9116 makes `Expires` mandatory and tells researchers to treat the whole file as invalid once that date passes, so the disclosure contact was on a timer — still served, just no longer worth acting on.

This replaces it with the route already live on fxrm.com: `Expires` rolls on the month boundary a year out, always inside the RFC 9116 §2.5.5 limit, and the body is stable day to day so it doesn't churn caches.

**After**

```
Contact: mailto:security@fxrm.com
Expires: 2027-08-01T00:00:00Z
Preferred-Languages: en
Canonical: https://task.me.uk/.well-known/security.txt
```

The static file at `public/.well-known/security.txt` is deleted in the same commit — LiteSpeed serves it directly and would shadow the route otherwise. That deletion is load-bearing, not tidying.

`Contact` is unchanged. security@fxrm.com is what the site already advertises.

### Tests

Five in `tests/Feature/SecurityTxtTest.php`. The one that matters winds the clock to 2030 and asserts `Expires` is still in the future — that is the whole point of this being a route.

### Checks run locally

- `vendor/bin/pint --test` — passed
- `./vendor/bin/pest --filter=SecurityTxt` — 5 passed, 8 assertions

The full suite has heavy pre-existing failures on this machine (`MissingAppKeyException` — no local `APP_KEY`). I confirmed they are pre-existing by running the suite at the base commit with my change stashed: identical failures. With a runtime `APP_KEY` supplied, my five tests pass.

One of ~13 identical changes rolling this across the estate.