### PR TITLE
feat: add a currency toggle alongside the language toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Using as many FluxUI features as I can to simplify design (as I'm lousy at desig
 - Sortable and filterable
 - Keyboard shortcuts (Cmd-A add, Cmd-K search)
 - Multiple languages (locale) supported with translations for Portugese, Spanish, French, Italian, German and Russian so far (thanks to ChatGPT - if someone wants to tidy them up, please feel free!)
+- Currency toggle (GBP, EUR, USD, CAD, AUD, CHF, JPY) which overrides the currency guessed from the locale
 - Export and import your tasks to a json format
 - Mobile friendly interface
 

--- a/app/Facades/Currency.php
+++ b/app/Facades/Currency.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * (C) Jon Morby 2025.  All Rights Reserved.
+ */
+
+namespace App\Facades;
+
+use App\Support\CurrencyManager;
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * @method static array<string, array<string, mixed>> supported()
+ * @method static array<int, string> codes()
+ * @method static bool isSupported(?string $code)
+ * @method static string normalise(string $code)
+ * @method static string default()
+ * @method static string guess(?string $locale = null)
+ * @method static string|null override()
+ * @method static bool hasOverride()
+ * @method static string current()
+ * @method static void setCurrent(string $code)
+ * @method static void flush()
+ * @method static void store(string $code)
+ * @method static void forget()
+ * @method static array<string, mixed> definition(?string $code = null)
+ * @method static string symbol(?string $code = null)
+ * @method static string name(?string $code = null)
+ * @method static string format(int|float $amount, ?string $code = null)
+ *
+ * @see CurrencyManager
+ */
+class Currency extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return CurrencyManager::class;
+    }
+}

--- a/app/Http/Middleware/CurrencyMiddleware.php
+++ b/app/Http/Middleware/CurrencyMiddleware.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * (C) Jon Morby 2025.  All Rights Reserved.
+ */
+
+namespace App\Http\Middleware;
+
+use App\Support\CurrencyManager;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * This middleware starts each request with a clean currency, so the currency
+ * one visitor pinned cannot be carried into the next request where the
+ * container is reused.
+ *
+ * The currency itself is resolved when it is first needed: the choice stored
+ * in the session by the currency toggle always wins, and otherwise it is
+ * guessed from the locale LanguageMiddleware has set.
+ */
+class CurrencyMiddleware
+{
+    public function __construct(protected CurrencyManager $currency) {}
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $this->currency->flush();
+
+        return $next($request);
+    }
+}

--- a/app/Livewire/CurrencyMenu.php
+++ b/app/Livewire/CurrencyMenu.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * (C) Jon Morby 2025.  All Rights Reserved.
+ */
+
+namespace App\Livewire;
+
+use App\Facades\Currency;
+use Livewire\Component;
+
+/**
+ * This component is used to set the display currency.
+ * It is used in the header of the application, alongside the locale menu.
+ */
+/**
+ * @property string $currency
+ */
+class CurrencyMenu extends Component
+{
+    public string $currency;
+
+    public function __construct()
+    {
+        $this->currency = Currency::current();
+    }
+
+    public function render()
+    {
+        return view('livewire.currency-menu', [
+            'currencies' => Currency::supported(),
+        ]);
+    }
+
+    /*
+         * This method is used to set the display currency, overriding the
+         * currency we would otherwise guess from the locale.
+         *
+         * @param string $code
+         * @return \Illuminate\Http\RedirectResponse
+         */
+    public function setCurrency($code)
+    {
+        if (! Currency::isSupported($code)) {
+            return null;
+        }
+
+        $this->currency = Currency::normalise($code);
+        Currency::store($this->currency);
+        $this->dispatch('currency-changed', $this->currency);
+
+        return redirect(request()->header('Referer'));
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Support\CurrencyManager;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -11,7 +12,9 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->app->singleton(CurrencyManager::class, function ($app) {
+            return new CurrencyManager($app['config'], $app['session.store']);
+        });
     }
 
     /**

--- a/app/Support/CurrencyManager.php
+++ b/app/Support/CurrencyManager.php
@@ -1,0 +1,246 @@
+<?php
+
+/**
+ * (C) Jon Morby 2025.  All Rights Reserved.
+ */
+
+namespace App\Support;
+
+use Illuminate\Contracts\Config\Repository as Config;
+use Illuminate\Contracts\Session\Session;
+use Illuminate\Support\Facades\App;
+
+/**
+ * Resolves the currency used to display monetary amounts.
+ *
+ * The currency is worked out the same way the locale is: a choice the visitor
+ * has made (stored in the session by the currency toggle) always wins, and
+ * otherwise we guess from the active locale before falling back to the
+ * configured default.
+ */
+class CurrencyManager
+{
+    /**
+     * The session key holding the visitor's explicit choice.
+     */
+    public const SESSION_KEY = 'currency';
+
+    /**
+     * A currency pinned for this request only, if one has been pinned.
+     */
+    protected ?string $pinned = null;
+
+    public function __construct(
+        protected Config $config,
+        protected Session $session,
+    ) {}
+
+    /**
+     * All of the currencies the toggle offers, keyed by ISO 4217 code.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public function supported(): array
+    {
+        /** @var array<string, array<string, mixed>> $supported */
+        $supported = $this->config->get('currency.supported', []);
+
+        return $supported;
+    }
+
+    /**
+     * The codes of all supported currencies.
+     *
+     * @return array<int, string>
+     */
+    public function codes(): array
+    {
+        return array_keys($this->supported());
+    }
+
+    /**
+     * Determine whether the given code is one we can display.
+     */
+    public function isSupported(?string $code): bool
+    {
+        return $code !== null && array_key_exists($this->normalise($code), $this->supported());
+    }
+
+    /**
+     * Tidy a user supplied code into the form used as a config key.
+     */
+    public function normalise(string $code): string
+    {
+        return strtoupper(trim($code));
+    }
+
+    /**
+     * The currency used when we know nothing about the visitor.
+     */
+    public function default(): string
+    {
+        $default = $this->config->get('currency.default');
+
+        if (is_string($default) && $this->isSupported($default)) {
+            return $this->normalise($default);
+        }
+
+        return $this->codes()[0] ?? 'GBP';
+    }
+
+    /**
+     * Guess a currency from a locale, ignoring any choice the visitor made.
+     */
+    public function guess(?string $locale = null): string
+    {
+        $locale = str_replace('-', '_', $locale ?? App::getLocale());
+
+        /** @var array<string, string> $map */
+        $map = $this->config->get('currency.locales', []);
+
+        // Prefer the most specific match, e.g. "fr_CA" before "fr".
+        foreach ([$locale, explode('_', $locale)[0]] as $candidate) {
+            if (isset($map[$candidate]) && $this->isSupported($map[$candidate])) {
+                return $this->normalise($map[$candidate]);
+            }
+        }
+
+        return $this->default();
+    }
+
+    /**
+     * The currency the visitor has explicitly chosen, if any.
+     */
+    public function override(): ?string
+    {
+        $stored = $this->session->get(self::SESSION_KEY);
+
+        if (is_string($stored) && $this->isSupported($stored)) {
+            return $this->normalise($stored);
+        }
+
+        return null;
+    }
+
+    /**
+     * Determine whether the visitor has overridden the locale based guess.
+     */
+    public function hasOverride(): bool
+    {
+        return $this->override() !== null;
+    }
+
+    /**
+     * The currency to display amounts in.
+     *
+     * This is resolved on every call rather than cached, so a choice stored
+     * part way through a request (or once the session has been started) is
+     * picked up straight away.
+     */
+    public function current(): string
+    {
+        return $this->pinned ?? $this->override() ?? $this->guess();
+    }
+
+    /**
+     * Use the given currency for the rest of this request only.
+     */
+    public function setCurrent(string $code): void
+    {
+        if ($this->isSupported($code)) {
+            $this->pinned = $this->normalise($code);
+        }
+    }
+
+    /**
+     * Drop any currency pinned for the current request.
+     *
+     * Called at the start of each request so that a currency pinned by one
+     * request cannot leak into the next where the container is reused.
+     */
+    public function flush(): void
+    {
+        $this->pinned = null;
+    }
+
+    /**
+     * Remember the given currency for this visitor, overriding the guess.
+     */
+    public function store(string $code): void
+    {
+        if (! $this->isSupported($code)) {
+            return;
+        }
+
+        $code = $this->normalise($code);
+
+        $this->session->put(self::SESSION_KEY, $code);
+        $this->pinned = $code;
+    }
+
+    /**
+     * Drop the visitor's choice and fall back to the locale based guess.
+     */
+    public function forget(): void
+    {
+        $this->session->forget(self::SESSION_KEY);
+        $this->pinned = null;
+    }
+
+    /**
+     * The display settings for a currency.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(?string $code = null): array
+    {
+        $code = $code !== null && $this->isSupported($code)
+            ? $this->normalise($code)
+            : $this->current();
+
+        return $this->supported()[$code] ?? [];
+    }
+
+    /**
+     * The symbol a currency is written with, e.g. "£".
+     */
+    public function symbol(?string $code = null): string
+    {
+        $definition = $this->definition($code);
+
+        return is_string($definition['symbol'] ?? null) ? $definition['symbol'] : '';
+    }
+
+    /**
+     * The translated name of a currency, e.g. "British Pound".
+     */
+    public function name(?string $code = null): string
+    {
+        $definition = $this->definition($code);
+
+        return is_string($definition['name'] ?? null) ? __($definition['name']) : '';
+    }
+
+    /**
+     * Render an amount in the current (or given) currency.
+     */
+    public function format(int|float $amount, ?string $code = null): string
+    {
+        $definition = $this->definition($code);
+
+        $number = number_format(
+            abs($amount),
+            (int) ($definition['decimals'] ?? 2),
+            (string) ($definition['decimal_separator'] ?? '.'),
+            (string) ($definition['thousands_separator'] ?? ','),
+        );
+
+        $symbol = is_string($definition['symbol'] ?? null) ? $definition['symbol'] : '';
+
+        $formatted = ($definition['position'] ?? 'before') === 'after'
+            ? $number.' '.$symbol
+            : $symbol.$number;
+
+        return ($amount < 0 ? '-' : '').trim($formatted);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\CurrencyMiddleware;
 use App\Http\Middleware\LanguageMiddleware;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
@@ -13,7 +14,9 @@ return Application::configure(basePath: dirname(__DIR__))
         api: __DIR__.'/../routes/api.php',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        $middleware->append([LanguageMiddleware::class]);
+        // CurrencyMiddleware follows LanguageMiddleware: the currency we show
+        // a visitor is guessed from the locale that has just been set.
+        $middleware->append([LanguageMiddleware::class, CurrencyMiddleware::class]);
 
     })
     ->withExceptions(function (Exceptions $exceptions) {

--- a/config/currency.php
+++ b/config/currency.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * (C) Jon Morby 2025.  All Rights Reserved.
+ */
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Currency
+    |--------------------------------------------------------------------------
+    |
+    | The currency used when nothing better is known about the visitor: no
+    | currency has been chosen in the session and the active locale does not
+    | map to one of the supported currencies below.
+    |
+    */
+
+    'default' => env('APP_CURRENCY', 'GBP'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Supported Currencies
+    |--------------------------------------------------------------------------
+    |
+    | The currencies offered by the currency toggle. Each entry is keyed by its
+    | ISO 4217 code and describes how amounts in that currency are rendered.
+    | The "name" is passed through the translator, so it must also exist as a
+    | key in the language files.
+    |
+    */
+
+    'supported' => [
+        'GBP' => [
+            'name' => 'British Pound',
+            'symbol' => '£',
+            'position' => 'before',
+            'decimals' => 2,
+            'decimal_separator' => '.',
+            'thousands_separator' => ',',
+        ],
+        'EUR' => [
+            'name' => 'Euro',
+            'symbol' => '€',
+            'position' => 'before',
+            'decimals' => 2,
+            'decimal_separator' => ',',
+            'thousands_separator' => '.',
+        ],
+        'USD' => [
+            'name' => 'US Dollar',
+            'symbol' => '$',
+            'position' => 'before',
+            'decimals' => 2,
+            'decimal_separator' => '.',
+            'thousands_separator' => ',',
+        ],
+        'CAD' => [
+            'name' => 'Canadian Dollar',
+            'symbol' => 'CA$',
+            'position' => 'before',
+            'decimals' => 2,
+            'decimal_separator' => '.',
+            'thousands_separator' => ',',
+        ],
+        'AUD' => [
+            'name' => 'Australian Dollar',
+            'symbol' => 'A$',
+            'position' => 'before',
+            'decimals' => 2,
+            'decimal_separator' => '.',
+            'thousands_separator' => ',',
+        ],
+        'CHF' => [
+            'name' => 'Swiss Franc',
+            'symbol' => 'CHF',
+            'position' => 'before',
+            'decimals' => 2,
+            'decimal_separator' => '.',
+            'thousands_separator' => "'",
+        ],
+        'JPY' => [
+            'name' => 'Japanese Yen',
+            'symbol' => '¥',
+            'position' => 'before',
+            'decimals' => 0,
+            'decimal_separator' => '.',
+            'thousands_separator' => ',',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Locale Guesses
+    |--------------------------------------------------------------------------
+    |
+    | Maps an application locale onto the currency we assume the visitor wants
+    | until they tell us otherwise. A choice stored in the session always wins
+    | over these guesses. Keys may be a bare language ("fr") or a full locale
+    | ("fr_CA"); the more specific match is preferred.
+    |
+    */
+
+    'locales' => [
+        'en' => 'GBP',
+        'en_GB' => 'GBP',
+        'en_US' => 'USD',
+        'en_CA' => 'CAD',
+        'en_AU' => 'AUD',
+        'de' => 'EUR',
+        'de_CH' => 'CHF',
+        'es' => 'EUR',
+        'fr' => 'EUR',
+        'fr_CA' => 'CAD',
+        'fr_CH' => 'CHF',
+        'it' => 'EUR',
+        'it_CH' => 'CHF',
+        'pt' => 'EUR',
+        'ru' => 'EUR',
+        'ja' => 'JPY',
+    ],
+
+];

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -99,5 +99,13 @@
     "Update Password": "Passwort aktualisieren",
     "Password Updated Successfully": "Passwort erfolgreich aktualisiert",
     "Profile Updated Successfully": "Profil erfolgreich aktualisiert",
-    "Platform": "Plattform"
+    "Platform": "Plattform",
+    "Currency": "Währung",
+    "British Pound": "Britisches Pfund",
+    "Euro": "Euro",
+    "US Dollar": "US-Dollar",
+    "Canadian Dollar": "Kanadischer Dollar",
+    "Australian Dollar": "Australischer Dollar",
+    "Swiss Franc": "Schweizer Franken",
+    "Japanese Yen": "Japanischer Yen"
 }

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -99,5 +99,13 @@
     "Update Password": "Update Password",
     "Password Updated Successfully": "Password Updated Successfully",
     "Profile Updated Successfully": "Profile Updated Successfully",
-    "Platform": "Platform"
+    "Platform": "Platform",
+    "Currency": "Currency",
+    "British Pound": "British Pound",
+    "Euro": "Euro",
+    "US Dollar": "US Dollar",
+    "Canadian Dollar": "Canadian Dollar",
+    "Australian Dollar": "Australian Dollar",
+    "Swiss Franc": "Swiss Franc",
+    "Japanese Yen": "Japanese Yen"
 }

--- a/resources/lang/es.json
+++ b/resources/lang/es.json
@@ -99,5 +99,13 @@
     "Update Password": "Actualizar Contraseña",
     "Password Updated Successfully": "Contraseña Actualizada Exitosamente",
     "Profile Updated Successfully": "Perfil Actualizado Exitosamente",
-    "Platform": "Plataforma"
+    "Platform": "Plataforma",
+    "Currency": "Moneda",
+    "British Pound": "Libra esterlina",
+    "Euro": "Euro",
+    "US Dollar": "Dólar estadounidense",
+    "Canadian Dollar": "Dólar canadiense",
+    "Australian Dollar": "Dólar australiano",
+    "Swiss Franc": "Franco suizo",
+    "Japanese Yen": "Yen japonés"
 }

--- a/resources/lang/fr.json
+++ b/resources/lang/fr.json
@@ -99,5 +99,13 @@
     "Update Password": "Mettre à jour le mot de passe",
     "Password Updated Successfully": "Mot de passe mis à jour avec succès",
     "Profile Updated Successfully": "Profil mis à jour avec succès",
-    "Platform": "Plateforme"
+    "Platform": "Plateforme",
+    "Currency": "Devise",
+    "British Pound": "Livre sterling",
+    "Euro": "Euro",
+    "US Dollar": "Dollar américain",
+    "Canadian Dollar": "Dollar canadien",
+    "Australian Dollar": "Dollar australien",
+    "Swiss Franc": "Franc suisse",
+    "Japanese Yen": "Yen japonais"
 }

--- a/resources/lang/it.json
+++ b/resources/lang/it.json
@@ -99,5 +99,13 @@
     "Update Password": "Aggiorna password",
     "Password Updated Successfully": "Password aggiornata con successo",
     "Profile Updated Successfully": "Profilo aggiornato con successo",
-    "Platform": "Piattaforma"
+    "Platform": "Piattaforma",
+    "Currency": "Valuta",
+    "British Pound": "Sterlina britannica",
+    "Euro": "Euro",
+    "US Dollar": "Dollaro statunitense",
+    "Canadian Dollar": "Dollaro canadese",
+    "Australian Dollar": "Dollaro australiano",
+    "Swiss Franc": "Franco svizzero",
+    "Japanese Yen": "Yen giapponese"
 }

--- a/resources/lang/pt.json
+++ b/resources/lang/pt.json
@@ -99,5 +99,13 @@
     "Update Password": "Update Password",
     "Password Updated Successfully": "Password Updated Successfully",
     "Profile Updated Successfully": "Profile Updated Successfully",
-    "Platform": "Platform"
+    "Platform": "Platform",
+    "Currency": "Moeda",
+    "British Pound": "Libra esterlina",
+    "Euro": "Euro",
+    "US Dollar": "Dólar americano",
+    "Canadian Dollar": "Dólar canadiano",
+    "Australian Dollar": "Dólar australiano",
+    "Swiss Franc": "Franco suíço",
+    "Japanese Yen": "Iene japonês"
 }

--- a/resources/lang/ru.json
+++ b/resources/lang/ru.json
@@ -99,5 +99,13 @@
     "Update Password": "Обновить пароль",
     "Password Updated Successfully": "Пароль успешно обновлен",
     "Profile Updated Successfully": "Профиль успешно обновлен",
-    "Platform": "Платформа"
+    "Platform": "Платформа",
+    "Currency": "Валюта",
+    "British Pound": "Фунт стерлингов",
+    "Euro": "Евро",
+    "US Dollar": "Доллар США",
+    "Canadian Dollar": "Канадский доллар",
+    "Australian Dollar": "Австралийский доллар",
+    "Swiss Franc": "Швейцарский франк",
+    "Japanese Yen": "Японская иена"
 }

--- a/resources/lang/xx-pirate.json
+++ b/resources/lang/xx-pirate.json
@@ -99,5 +99,13 @@
     "Update Password": "Update Yer Lock",
     "Password Updated Successfully": "Secret Code Now Safe from Mutineers!",
     "Profile Updated Successfully": "Yer Legend Has Been Updated!",
-    "Platform": "Deck"
+    "Platform": "Deck",
+    "Currency": "Coin o' the Realm",
+    "British Pound": "Ol' Blighty Pound",
+    "Euro": "Euro Doubloon",
+    "US Dollar": "Yankee Dollar",
+    "Canadian Dollar": "Maple Dollar",
+    "Australian Dollar": "Down Under Dollar",
+    "Swiss Franc": "Mountain Franc",
+    "Japanese Yen": "Yen o' the East"
 }

--- a/resources/views/components/currency-menu-item.blade.php
+++ b/resources/views/components/currency-menu-item.blade.php
@@ -1,0 +1,9 @@
+@props(['code', 'name', 'symbol' => '', 'current' => null])
+
+<flux:navmenu.item wire:click="setCurrency('{{ $code }}')">{{ $symbol }} {{ __($name) }}
+    @if ($current === $code)
+        <svg class="w-5 h-5 text-green-500 mr-2" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+            stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+    </svg> @endif
+</flux:navmenu.item>

--- a/resources/views/components/layouts/app/header.blade.php
+++ b/resources/views/components/layouts/app/header.blade.php
@@ -26,6 +26,7 @@
                     <flux:navbar.item class="!h-10 [&>div>svg]:size-5" icon="magnifying-glass" href="#" :label="__('Search')" />
                 </flux:tooltip> --}}
                                 <livewire:locale-menu />
+                <livewire:currency-menu />
 
                 <flux:tooltip :content="__('Repository')" position="bottom">
                     <flux:navbar.item

--- a/resources/views/livewire/currency-menu.blade.php
+++ b/resources/views/livewire/currency-menu.blade.php
@@ -1,0 +1,16 @@
+<div x-data="">
+    <flux:dropdown position="bottom" align="end">
+        <flux:button icon-trailing="chevron-down" :aria-label="__('Currency')">{{ $currency }}</flux:button>
+
+        <flux:navmenu>
+            @foreach ($currencies as $code => $definition)
+                <x-currency-menu-item
+                    :code="$code"
+                    :name="$definition['name']"
+                    :symbol="$definition['symbol']"
+                    :current="$currency"
+                />
+            @endforeach
+        </flux:navmenu>
+    </flux:dropdown>
+</div>

--- a/tests/Feature/CurrencyManagerTest.php
+++ b/tests/Feature/CurrencyManagerTest.php
@@ -1,0 +1,91 @@
+<?php
+
+use App\Facades\Currency;
+use App\Support\CurrencyManager;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Session;
+
+beforeEach(function () {
+    Session::forget(CurrencyManager::SESSION_KEY);
+    App::setLocale('en');
+});
+
+test('it guesses a currency from the language part of a locale', function () {
+    expect(Currency::guess('fr'))->toBe('EUR')
+        ->and(Currency::guess('ru'))->toBe('EUR')
+        ->and(Currency::guess('en'))->toBe('GBP');
+});
+
+test('it prefers the most specific locale match', function () {
+    expect(Currency::guess('en_US'))->toBe('USD')
+        ->and(Currency::guess('en-US'))->toBe('USD')
+        ->and(Currency::guess('fr_CA'))->toBe('CAD')
+        ->and(Currency::guess('de_CH'))->toBe('CHF');
+});
+
+test('it falls back to the default currency for an unknown locale', function () {
+    config()->set('currency.default', 'USD');
+
+    expect(Currency::guess('xx-pirate'))->toBe('USD');
+});
+
+test('it falls back to a supported currency when the default is unknown', function () {
+    config()->set('currency.default', 'ZZZ');
+
+    expect(Currency::default())->toBe('GBP');
+});
+
+test('it ignores an unsupported currency held in the session', function () {
+    App::setLocale('fr');
+    Session::put(CurrencyManager::SESSION_KEY, 'ZZZ');
+
+    expect(Currency::override())->toBeNull()
+        ->and(Currency::hasOverride())->toBeFalse()
+        ->and(Currency::current())->toBe('EUR');
+});
+
+test('forgetting the override falls back to the guess', function () {
+    App::setLocale('fr');
+    Currency::store('USD');
+
+    expect(Currency::current())->toBe('USD');
+
+    Currency::forget();
+
+    expect(Currency::hasOverride())->toBeFalse()
+        ->and(Currency::current())->toBe('EUR');
+});
+
+test('setCurrent does not persist the currency to the session', function () {
+    Currency::setCurrent('JPY');
+
+    expect(Currency::current())->toBe('JPY')
+        ->and(Session::has(CurrencyManager::SESSION_KEY))->toBeFalse();
+});
+
+test('it exposes the symbol and translated name of a currency', function () {
+    expect(Currency::symbol('GBP'))->toBe('£')
+        ->and(Currency::symbol('EUR'))->toBe('€')
+        ->and(Currency::name('USD'))->toBe('US Dollar');
+});
+
+test('it formats amounts using the settings of the currency', function () {
+    expect(Currency::format(1234.5, 'GBP'))->toBe('£1,234.50')
+        ->and(Currency::format(1234.5, 'EUR'))->toBe('€1.234,50')
+        ->and(Currency::format(1234.5, 'JPY'))->toBe('¥1,235')
+        ->and(Currency::format(1234.5, 'CHF'))->toBe("CHF1'234.50")
+        ->and(Currency::format(-99, 'USD'))->toBe('-$99.00');
+});
+
+test('it formats amounts in the current currency by default', function () {
+    Currency::store('USD');
+
+    expect(Currency::format(10))->toBe('$10.00');
+});
+
+test('it lists the supported currency codes', function () {
+    expect(Currency::codes())->toContain('GBP', 'EUR', 'USD')
+        ->and(Currency::isSupported('gbp'))->toBeTrue()
+        ->and(Currency::isSupported('ZZZ'))->toBeFalse()
+        ->and(Currency::isSupported(null))->toBeFalse();
+});

--- a/tests/Feature/CurrencyMenuTest.php
+++ b/tests/Feature/CurrencyMenuTest.php
@@ -1,0 +1,85 @@
+<?php
+
+use App\Facades\Currency;
+use App\Livewire\CurrencyMenu;
+use App\Models\User;
+use App\Support\CurrencyManager;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Session;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    Session::forget(CurrencyManager::SESSION_KEY);
+    App::setLocale('en');
+});
+
+test('currency menu component can be rendered', function () {
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    $response = $this->get('/dashboard');
+    $response->assertStatus(200);
+    $response->assertSeeLivewire(CurrencyMenu::class);
+});
+
+test('currency menu uses the currency stored in the session', function () {
+    Session::put(CurrencyManager::SESSION_KEY, 'JPY');
+
+    $component = Livewire::test(CurrencyMenu::class);
+
+    expect($component->get('currency'))->toBe('JPY');
+});
+
+test('currency menu guesses from the locale when nothing is stored', function () {
+    App::setLocale('de');
+
+    $component = Livewire::test(CurrencyMenu::class);
+
+    expect($component->get('currency'))->toBe('EUR');
+});
+
+test('a stored currency overrides the locale guess', function () {
+    App::setLocale('de');
+    Session::put(CurrencyManager::SESSION_KEY, 'USD');
+
+    expect(Currency::guess())->toBe('EUR')
+        ->and(Currency::current())->toBe('USD');
+});
+
+test('setCurrency stores the chosen currency', function () {
+    $component = Livewire::test(CurrencyMenu::class)
+        ->call('setCurrency', 'USD');
+
+    expect($component->get('currency'))->toBe('USD')
+        ->and(Session::get(CurrencyManager::SESSION_KEY))->toBe('USD')
+        ->and(Currency::current())->toBe('USD');
+});
+
+test('setCurrency accepts a lower case code', function () {
+    Livewire::test(CurrencyMenu::class)
+        ->call('setCurrency', 'eur');
+
+    expect(Session::get(CurrencyManager::SESSION_KEY))->toBe('EUR');
+});
+
+test('setCurrency dispatches currency-changed event', function () {
+    Livewire::test(CurrencyMenu::class)
+        ->call('setCurrency', 'CHF')
+        ->assertDispatched('currency-changed', 'CHF');
+});
+
+test('setCurrency ignores an unsupported currency', function () {
+    Livewire::test(CurrencyMenu::class)
+        ->call('setCurrency', 'XYZ')
+        ->assertNotDispatched('currency-changed');
+
+    expect(Session::has(CurrencyManager::SESSION_KEY))->toBeFalse();
+});
+
+test('setCurrency redirects back to the referrer', function () {
+    $this->withHeaders(['Referer' => 'http://localhost/dashboard']);
+
+    Livewire::test(CurrencyMenu::class)->call('setCurrency', 'AUD');
+
+    expect(Session::get(CurrencyManager::SESSION_KEY))->toBe('AUD');
+});

--- a/tests/Feature/CurrencyMiddlewareTest.php
+++ b/tests/Feature/CurrencyMiddlewareTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Facades\Currency;
+use App\Support\CurrencyManager;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Route;
+
+beforeEach(function () {
+    Route::middleware('web')->get('/__currency-probe', function () {
+        return Currency::current().'|'.(Currency::hasOverride() ? 'override' : 'guess');
+    });
+});
+
+test('a request without a stored currency uses the locale guess', function () {
+    App::setLocale('de');
+
+    $this->get('/__currency-probe')->assertSee('EUR|guess');
+});
+
+test('a request with a stored currency uses it instead of the guess', function () {
+    App::setLocale('de');
+
+    $this->withSession([CurrencyManager::SESSION_KEY => 'JPY'])
+        ->get('/__currency-probe')
+        ->assertSee('JPY|override');
+});
+
+test('a currency pinned for one request does not leak into the next', function () {
+    Currency::setCurrent('JPY');
+
+    expect(Currency::current())->toBe('JPY');
+
+    App::setLocale('en');
+    $this->get('/__currency-probe')->assertSee('GBP|guess');
+});


### PR DESCRIPTION
Adds a currency menu to the header that works the way the locale menu
does: the visitor's choice is stored in the session and overrides the
currency we would otherwise guess from the active locale.

- config/currency.php holds the supported currencies (GBP, EUR, USD,
  CAD, AUD, CHF, JPY), the locale to currency guesses and the default
- CurrencyManager resolves the currency (session choice, then locale
  guess, then default) and formats amounts for it
- CurrencyMiddleware clears the request scoped currency so a currency
  pinned by one request cannot leak into the next
- CurrencyMenu Livewire component plus its views, added to the header
- Currency names translated into all of the supported languages
- Feature tests for the manager, the middleware and the menu

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Eg7t6nqKTaY1PFg1hcFuUz